### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,17 @@
 settings.py
+# Created by https://www.gitignore.io/api/web
+
+### Web ###
+*.asp
+*.cer
+*.csr
+*.css
+*.htm
+*.html
+*.js
+*.jsp
+*.php
+*.rss
+*.xhtml
+
+# End of https://www.gitignore.io/api/web


### PR DESCRIPTION
¿Qué ha cambiado?
Agregamos al gitignore soporte para web
- [ ] Frontend
- [ x] Backend

# Como probar los cambios
Por ejemplo, los archivos y la carpeta node_modules no se subiran al repo, ver el archivo .gitignore
